### PR TITLE
Skip failing summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ async def main():
     print(f"\nProcessed {len(conversations)} conversations")
     print(f"Created {len(reduced_clusters)} meta clusters")
     print(f"Checkpoints saved to: {checkpoint_manager.checkpoint_dir}")
+    print("Failed summaries are stored in summaries_errors.jsonl if any errors occurred")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/kura/base_classes/summarisation.py
+++ b/kura/base_classes/summarisation.py
@@ -11,6 +11,14 @@ class BaseSummaryModel(ABC):
         """The filename to use for checkpointing this model's output."""
         pass
 
+    @property
+    def error_checkpoint_filename(self) -> str:
+        """Filename for storing summarisation errors."""
+        filename = self.checkpoint_filename
+        if filename.endswith(".jsonl"):
+            return filename.replace(".jsonl", "_errors.jsonl")
+        return f"{filename}_errors.jsonl"
+
     @abstractmethod
     async def summarise(
         self, conversations: list[Conversation]

--- a/kura/kura.py
+++ b/kura/kura.py
@@ -149,6 +149,13 @@ class Kura:
         )
 
     @property
+    def summary_error_checkpoint_path(self) -> str:
+        """Path for storing summarisation errors."""
+        return os.path.join(
+            self.checkpoint_dir, self.summarisation_model.error_checkpoint_filename
+        )
+
+    @property
     def cluster_checkpoint_path(self) -> str:
         """Get the checkpoint path for clusters based on the cluster model."""
         return os.path.join(self.checkpoint_dir, self.cluster_model.checkpoint_filename)
@@ -277,6 +284,12 @@ class Kura:
 
         summaries = await self.summarisation_model.summarise(conversations)
         self.save_checkpoint(self.summary_checkpoint_path, summaries)
+
+        if self.summarisation_model.errors:
+            self.save_checkpoint(
+                self.summary_error_checkpoint_path, self.summarisation_model.errors
+            )
+
         return summaries
 
     async def generate_base_clusters(

--- a/kura/types/summarisation.py
+++ b/kura/types/summarisation.py
@@ -49,3 +49,10 @@ class ConversationSummary(GeneratedSummary):
 class ExtractedProperty(BaseModel):
     name: str
     value: Union[str, int, float, bool, list[str], list[int], list[float]]
+
+
+class SummarisationError(BaseModel):
+    """Represents a failure to summarise a conversation."""
+
+    chat_id: str
+    error: str


### PR DESCRIPTION
## Summary
- skip summaries that raise and record them in a new errors checkpoint
- expose `error_checkpoint_filename` on summary models
- document the new behaviour in README

## Testing
- `pre-commit run --files README.md kura/base_classes/summarisation.py kura/kura.py kura/summarisation.py kura/types/summarisation.py kura/v1/kura.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68468b729cac832483712d1205e5d2e4